### PR TITLE
Add shorten endpoint

### DIFF
--- a/spec/shortnatra_spec.rb
+++ b/spec/shortnatra_spec.rb
@@ -7,30 +7,56 @@ RSpec.describe ShortNatra do
 
   describe "POST /shorten" do
     context "with code param" do
-      it "returns 201 created if code is valid" do
-
+      it "returns 201 and creates ShortUrl if code and url is valid" do
+        post "/shorten", {code: "code1", url: "http://www.google.com"}
+        expect(last_response.status).to eq 201
+        url = ShortUrl.find(code: "code1").first
+        expect(url).not_to eq(nil)
+        expect(url.url).to eq("http://www.google.com")
       end
 
       it "returns 409 if code is already exists" do
-
+        ShortUrl.new(code: "code1", url: "http://www.google.com").save
+        post "/shorten", {code: "code1", url: "http://www.google.com"}
+        expect(last_response.status).to eq 409
       end
 
       it "returns 402 if code is invalid regex" do
-
+        post "/shorten", {code: "c-x", url: "http://www.google.com"}
+        expect(last_response.status).to eq 402
+        url = ShortUrl.find(code: "c-x").first
+        expect(url).to eq(nil)
       end
 
       it "returns 400 if url is missing" do
+        post "/shorten", {code: "c-x"}
+        expect(last_response.status).to eq 400
+      end
 
+      it "returns 400 if url is invalid" do
+        post "/shorten", {code: "c-x", url: "invalidurl"}
+        expect(last_response.status).to eq 400
       end
     end
 
     context "without code param" do
-      it "returns 201 if url is present" do
-
+      it "returns 201 and creates ShortUrl if url is present" do
+        post "/shorten", {url: "http://www.google.com"}
+        expect(last_response.status).to eq 201
+        code = JSON.parse(last_response.body)[:shortcode]
+        url = ShortUrl.find(code: code).first
+        expect(url).not_to eq(nil)
+        expect(url.url).to eq("http://www.google.com")
       end
 
       it "returns 400 if url is missing" do
+        post "/shorten", {}
+        expect(last_response.status).to eq 400
+      end
 
+      it "returns 400 if url is invalid" do
+        post "/shorten", {url: "invalidurl"}
+        expect(last_response.status).to eq 400
       end
     end
   end
@@ -38,12 +64,12 @@ RSpec.describe ShortNatra do
   describe "GET /:shortcode" do
     context "with valid shortcode" do
       it "returns 302 redirect" do
-
+        pending "TODO"
       end
     end
     context "with invalid shortcode" do
       it "returns 404 not found" do
-
+        pending "TODO"
       end
     end
   end
@@ -51,12 +77,12 @@ RSpec.describe ShortNatra do
   describe "GET /:shortcode/stats" do
     context "with valid shortcode" do
       it "returns shortcode stats" do
-
+        pending "TODO"
       end
     end
     context "with invalid shortcode" do
       it "returns 404 not found" do
-
+        pending "TODO"
       end
     end
   end

--- a/spec/shortnatra_spec.rb
+++ b/spec/shortnatra_spec.rb
@@ -21,20 +21,15 @@ RSpec.describe ShortNatra do
         expect(last_response.status).to eq 409
       end
 
-      it "returns 402 if code is invalid regex" do
+      it "returns 422 if code is invalid regex" do
         post "/shorten", {code: "c-x", url: "http://www.google.com"}
-        expect(last_response.status).to eq 402
+        expect(last_response.status).to eq 422
         url = ShortUrl.find(code: "c-x").first
         expect(url).to eq(nil)
       end
 
       it "returns 400 if url is missing" do
-        post "/shorten", {code: "c-x"}
-        expect(last_response.status).to eq 400
-      end
-
-      it "returns 400 if url is invalid" do
-        post "/shorten", {code: "c-x", url: "invalidurl"}
+        post "/shorten", {code: "code1"}
         expect(last_response.status).to eq 400
       end
     end
@@ -43,7 +38,7 @@ RSpec.describe ShortNatra do
       it "returns 201 and creates ShortUrl if url is present" do
         post "/shorten", {url: "http://www.google.com"}
         expect(last_response.status).to eq 201
-        code = JSON.parse(last_response.body)[:shortcode]
+        code = JSON.parse(last_response.body)["shortcode"]
         url = ShortUrl.find(code: code).first
         expect(url).not_to eq(nil)
         expect(url.url).to eq("http://www.google.com")
@@ -51,11 +46,6 @@ RSpec.describe ShortNatra do
 
       it "returns 400 if url is missing" do
         post "/shorten", {}
-        expect(last_response.status).to eq 400
-      end
-
-      it "returns 400 if url is invalid" do
-        post "/shorten", {url: "invalidurl"}
         expect(last_response.status).to eq 400
       end
     end


### PR DESCRIPTION
This PR adds **POST /shorten** endpoint to the app.
### POST /shorten

```
POST /shorten
Content-Type: "application/json"

{
  "url": "http://example.com",
  "shortcode": "example"
}
```

| Attribute | Description |
| --- | --- |
| **url** | url to shorten |
| shortcode | preferential shortcode |
##### Returns:

```
201 Created
Content-Type: "application/json"

{
  "shortcode": :shortcode
}
```

A random shortcode is generated if none is requested, the generated short code has exactly 6 alpahnumeric characters and passes the following regexp: `^[0-9a-zA-Z_]{6}$`.
##### Errors:

| Error | Description |
| --- | --- |
| 400 | `url` is not present |
| 409 | The the desired shortcode is already in use. **Shortcodes are case-sensitive**. |
| 422 | The shortcode fails to meet the following regexp: `^[0-9a-zA-Z_]{4,}$`. |
