### PR TITLE
Add shortcode endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :test do
   gem "rack-test"
   gem "ffaker"
   gem "database_cleaner"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     stal (0.1.0)
       redic
     tilt (2.0.2)
+    timecop (0.8.0)
 
 PLATFORMS
   ruby
@@ -65,6 +66,7 @@ DEPENDENCIES
   rspec
   sinatra
   sinatra-contrib
+  timecop
 
 BUNDLED WITH
    1.11.2

--- a/app.rb
+++ b/app.rb
@@ -22,6 +22,12 @@ class ShortUrl < Ohm::Model
     self.code ||= generate_code
   end
 
+  def hit!
+    self.last_seen_date = Time.now
+    self.redirect_count += 1
+    self.save
+  end
+
   private
     def generate_code
       code = SecureRandom.hex(6)

--- a/app.rb
+++ b/app.rb
@@ -66,8 +66,7 @@ class ShortNatra < Sinatra::Base
             {status: "error", message: "The the desired shortcode is already in use. **Shortcodes are case-sensitive**."}.to_json
           else
             status 201
-            url = ShortUrl.new(code: params[:code], url: params[:url])
-            url.save
+            url = ShortUrl.create(code: params[:code], url: params[:url])
             {shortcode: url.code}.to_json
           end
         else
@@ -76,8 +75,7 @@ class ShortNatra < Sinatra::Base
         end
       else
         status 201
-        url = ShortUrl.new(url: params[:url])
-        url.save
+        url = ShortUrl.create(url: params[:url])
         {shortcode: url.code}.to_json
       end
     else
@@ -86,4 +84,17 @@ class ShortNatra < Sinatra::Base
     end
   end
 
+  get '/:shortcode' do
+    url = ShortUrl.find(code: params[:shortcode]).first
+
+    if url.nil?
+      content_type :json
+      status 404
+      {status: "error", message: "The shortcode cannot be found in the system"}.to_json
+    else
+      url.hit!
+      status 302
+      redirect url.url
+    end
+  end
 end

--- a/spec/short_url_spec.rb
+++ b/spec/short_url_spec.rb
@@ -30,4 +30,27 @@ RSpec.describe ShortUrl, type: :model do
     url.save
     expect(url.start_date).not_to eq nil
   end
+
+  describe "hit!" do
+    let(:url) { ShortUrl.create(url: "http://www.google.com") }
+
+    it "updates redirect count" do
+      url.hit!
+      expect(url.redirect_count).to eq 1
+      url.hit!
+      expect(url.redirect_count).to eq 2
+    end
+
+    it "updates last seen date" do
+      Timecop.freeze(Time.now)
+      url.hit!
+      expect(url.last_seen_date).to eq Time.now
+    end
+
+    it "saves changes" do
+      url.hit!
+      saved_url = ShortUrl.find(code: url.code).first
+      expect(saved_url.redirect_count).to eq 1
+    end
+  end
 end

--- a/spec/shortnatra_spec.rb
+++ b/spec/shortnatra_spec.rb
@@ -53,10 +53,24 @@ RSpec.describe ShortNatra do
 
   describe "GET /:shortcode" do
     context "with valid shortcode" do
-      it "returns 302 redirect" do
-        pending "TODO"
+      let(:url){ ShortUrl.create(url: "http://www.google.com")}
+      before :each do
+        get "/#{url.code}"
+      end
+
+      it "returns 302 and redirect" do
+        expect(last_response.status).to eq 302
+        expect(last_response).to redirect_to "http://www.google.com"
+      end
+
+      it "updates url stats" do
+        Timecop.freeze(Time.now)
+        url = ShortUrl.find(code: url.code).first
+        expect(url.redirect_count).to eq 1
+        expect(url.last_seen_date).to eq Time.now
       end
     end
+
     context "with invalid shortcode" do
       it "returns 404 not found" do
         pending "TODO"

--- a/spec/shortnatra_spec.rb
+++ b/spec/shortnatra_spec.rb
@@ -73,7 +73,9 @@ RSpec.describe ShortNatra do
 
     context "with invalid shortcode" do
       it "returns 404 not found" do
-        pending "TODO"
+        get "/randomcode"
+        expect(last_response.status).to eq 0
+        expect(last_response.body).to have_content "The shortcode cannot be found in the system"
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require File.expand_path '../../app.rb', __FILE__
 require File.expand_path("../../environment", __FILE__)
 ENV['RACK_ENV'] = 'test'
 require 'database_cleaner'
+require 'timecop'
 
 RSpec.configure do |config|
   include Rack::Test::Methods


### PR DESCRIPTION
This PR adds *_GET /:shortcode *_ endpoint
### GET /:shortcode

```
GET /:shortcode
Content-Type: "application/json"
```

| Attribute | Description |
| --- | --- |
| **shortcode** | url encoded shortcode |
##### Returns

**302** response with the location header pointing to the shortened URL

```
HTTP/1.1 302 Found
Location: http://www.example.com
```
##### Errors

| Error | Description |
| --- | --- |
| 404 | The `shortcode` cannot be found in the system |
